### PR TITLE
fix: for access was denied when calling Glue in deployment issue refs: #28

### DIFF
--- a/src/kinesis.ts
+++ b/src/kinesis.ts
@@ -2,7 +2,7 @@
 import { Database } from '@aws-cdk/aws-glue-alpha';
 import { RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { CfnTable } from 'aws-cdk-lib/aws-glue';
-import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Role, ServicePrincipal, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
 import { LogGroup, LogStream, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
@@ -22,6 +22,22 @@ export class KinesisResources extends Construct {
 
     const firehoseRole = new Role(this, 'FirehoseRole', {
       assumedBy: new ServicePrincipal('firehose.amazonaws.com'),
+      inlinePolicies: {
+        ['gluePolicy']: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['glue:GetTableVersions'],
+              resources: [
+                props.cdrDatabaseName.catalogArn,
+                props.cdrDatabaseName.databaseArn,
+                `arn:aws:glue:${Stack.of(this).region}:${
+                  Stack.of(this).account
+                }:table/${props.cdrDatabaseName.databaseName}/*`,
+              ],
+            }),
+          ],
+        }),
+      },
     });
 
     props.processedCdrsBucket.grantWrite(firehoseRole);


### PR DESCRIPTION
Fix for issue#28 - Access was denied when calling Glue in deployment
https://github.com/aws-samples/amazon-chime-voiceconnector-cdr-processing/issues/28
Adding permission on firehoseRole to initiate GetTableVersions to Glue tables.