### PR TITLE
fix: for access was denied when calling Glue in deployment issue refs: #28

### DIFF
--- a/src/kinesis.ts
+++ b/src/kinesis.ts
@@ -2,7 +2,7 @@
 import { Database } from '@aws-cdk/aws-glue-alpha';
 import { RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { CfnTable } from 'aws-cdk-lib/aws-glue';
-import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Role, ServicePrincipal, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
 import { LogGroup, LogStream, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
@@ -22,6 +22,22 @@ export class KinesisResources extends Construct {
 
     const firehoseRole = new Role(this, 'FirehoseRole', {
       assumedBy: new ServicePrincipal('firehose.amazonaws.com'),
+      inlinePolicies: {
+        ['gluePolicy']: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['glue:GetTableVersions'],
+              resources: [
+                props.cdrDatabaseName.catalogArn,
+                props.cdrDatabaseName.databaseArn,
+                `arn:aws:glue:${Stack.of(this).region}:${
+                  Stack.of(this).account
+                }:table/${props.cdrDatabaseName.databaseName}/*`,
+              ],
+            }),
+          ],
+        }),
+      },
     });
 
     props.processedCdrsBucket.grantWrite(firehoseRole);

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -277,7 +277,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             "projection.month.type": "integer",
             "projection.year.range": "2023,2026",
             "projection.year.type": "integer",
-            "transient_lastDdlTime": "1684131926",
+            "transient_lastDdlTime": "1684875740",
           },
           "PartitionKeys": [
             {
@@ -440,6 +440,73 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           ],
           "Version": "2012-10-17",
         },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "glue:GetTableVersions",
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:",
+                          {
+                            "Ref": "AWS::Partition",
+                          },
+                          ":glue:us-east-1:",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":catalog",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:",
+                          {
+                            "Ref": "AWS::Partition",
+                          },
+                          ":glue:us-east-1:",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":database/",
+                          {
+                            "Ref": "GlueResourcesAmazonChimeSdkVoiceConnectorCdrsDB7BCD97",
+                          },
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:glue:us-east-1:",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":table/",
+                          {
+                            "Ref": "GlueResourcesAmazonChimeSdkVoiceConnectorCdrsDB7BCD97",
+                          },
+                          "/*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "gluePolicy",
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },


### PR DESCRIPTION
Fixes #
Fix for issue#28 - Access was denied when calling Glue in deployment  
Adding permission on firehoseRole to initiate GetTableVersions to Glue tables.